### PR TITLE
Remove obsolete package option for `xcolor`

### DIFF
--- a/src/spe.cls
+++ b/src/spe.cls
@@ -42,7 +42,7 @@
     \fi%
 }
 
-\RequirePackage[hyperref]{xcolor}
+\RequirePackage{xcolor}
 \definecolor{spelink}{HTML}{172b81}
 
 \RequirePackage[hidelinks, urlcolor=spelink, citecolor=black, linkcolor=black, colorlinks=true]{hyperref}


### PR DESCRIPTION
Removes the obsolete package option for `xcolor`.
Closes #4