### PR TITLE
Simpler section commands

### DIFF
--- a/src/spe.cls
+++ b/src/spe.cls
@@ -73,7 +73,6 @@
 \newcommand{\sperefp}[1]{(\speref{#1})}
 \newcommand{\spefirstref}[1]{\textbf{\speref{#1}}}
 \newcommand{\spefirstrefp}[1]{\textbf{\sperefp{#1}}}
-\newcommand\setcurrentname[1]{\def\@currentlabelname{``\textit{#1}''}}
 
 % Citations
 \RequirePackage[bibstyle=authoryear, giveninits=true, uniquename=init, maxbibnames=3, minbibnames=3, style=authoryear, dashed=false]{biblatex}

--- a/src/spe.cls
+++ b/src/spe.cls
@@ -45,6 +45,7 @@
 \RequirePackage[hyperref]{xcolor}
 \definecolor{spelink}{HTML}{172b81}
 
+\RequirePackage{titlesec}
 \RequirePackage[hidelinks, urlcolor=spelink, citecolor=black, linkcolor=black, colorlinks=true]{hyperref}
 \RequirePackage{listofitems}
 \RequirePackage{pgffor}
@@ -84,7 +85,7 @@
 \DeclareFieldFormat{url}{\url{#1}}
 
 % Section headings
-\RequirePackage{titlesec}
+% The package import of "titlesec" is done above because it needs to be before "hyperref".
 \titleformat{\section}[hang]{\Large \bfseries}{\thesection.}{1em}{}
 \titleformat{\subsection}[runin]{\normalsize \bfseries}{\thesubsection.}{1em}{}[.]
 \titleformat{\subsubsection}[runin]{\normalsize \bfseries \itshape}{\thesubsubsection.}{1em}{\indent}[.]

--- a/src/spe.cls
+++ b/src/spe.cls
@@ -90,9 +90,19 @@
 \titleformat{\subsection}[runin]{\normalsize \bfseries}{\thesubsection.}{1em}{}[.]
 \titleformat{\subsubsection}[runin]{\normalsize \bfseries \itshape}{\thesubsubsection.}{1em}{\indent}[.]
 
-\newcommand{\spesection}[1]{\section*{#1} \setcurrentname{#1}}
-\newcommand{\spesubsection}[1]{\subsection*{#1} \setcurrentname{#1}}
-\newcommand{\spesubsubsection}[1]{\subsubsection*{#1} \setcurrentname{#1}}
+% Prevent numbering for the unstarred versions of the section commands.
+\setcounter{secnumdepth}{0}
+
+% Has to be done after loading the "hyperref" package, which loads the "nameref" package.
+\NewCommandCopy{\@nameref}{\nameref}
+\RenewDocumentCommand{\nameref}{s m}{%
+    \textit{%
+        \IfBooleanTF{#1}
+            {\@nameref*{#2}}
+            {\@nameref{#2}}%
+    }%
+}
+
 \newcommand{\spesubsubsubsection}[1]{~\newline \indent \textit{#1.}}
 
 % Title

--- a/src/spe.cls
+++ b/src/spe.cls
@@ -103,7 +103,7 @@
     }%
 }
 
-\newcommand{\spesubsubsubsection}[1]{~\newline \indent \textit{#1.}}
+\newcommand{\subsubsubsection}[1]{~\newline \indent \textit{#1.}}
 
 % Title
 \newcommand{\latexmath}[1]{


### PR DESCRIPTION
Removes the requirement to have "special" `SPE` section commands.

Also removes the quotes around the output of `\nameref` because the existing command used both quotes and italics, and this is redundant nonsense.

Closes #16.